### PR TITLE
Add HOG + MLP digits classifier example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # VisaoComputacionalT2
+
+This repository contains a proof-of-concept pipeline for classifying images from the scikit-learn digits dataset.
+
+The script `digits_mlp.py` demonstrates how to extract HOG features using OpenCV and train an MLP classifier.
+
+## Requirements
+
+- Python 3
+- `opencv-python` (provides the `cv2` module)
+- `scikit-learn`
+- `numpy`
+
+## Usage
+
+Install the dependencies and run the script:
+
+```bash
+pip install opencv-python scikit-learn numpy
+python3 digits_mlp.py
+```
+
+The script will train the model and print a classification report.

--- a/digits_mlp.py
+++ b/digits_mlp.py
@@ -1,0 +1,38 @@
+import cv2
+import numpy as np
+from sklearn.datasets import load_digits
+from sklearn.model_selection import train_test_split
+from sklearn.neural_network import MLPClassifier
+from sklearn.metrics import classification_report, accuracy_score
+
+
+def extract_hog_features(images):
+    hog = cv2.HOGDescriptor()
+    features = []
+    for img in images:
+        img_resized = cv2.resize(img, (64, 64))
+        h = hog.compute(img_resized)
+        features.append(h.flatten())
+    return np.array(features)
+
+
+def main():
+    digits = load_digits()
+    X = digits.images
+    y = digits.target
+
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+
+    X_train_feat = extract_hog_features(X_train)
+    X_test_feat = extract_hog_features(X_test)
+
+    clf = MLPClassifier(hidden_layer_sizes=(100,), max_iter=300, random_state=42)
+    clf.fit(X_train_feat, y_train)
+
+    y_pred = clf.predict(X_test_feat)
+    print('Accuracy:', accuracy_score(y_test, y_pred))
+    print(classification_report(y_test, y_pred))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement a small computer vision pipeline `digits_mlp.py`
- update README with instructions for running the code

## Testing
- `python3 digits_mlp.py` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_684dec2220248331bd378d1711cdf4af